### PR TITLE
Implement Reset method in DocumentSectionRenderer

### DIFF
--- a/src/MarkdownExtensions/DocumentSectionsRenderer.cs
+++ b/src/MarkdownExtensions/DocumentSectionsRenderer.cs
@@ -14,6 +14,13 @@ public class DocumentSectionRenderer(ILogger? logger = null) : HtmlObjectRendere
 
     public IReadOnlyList<Section> Sections => _sections;
 
+    public void Reset()
+    {
+        logger?.LogDebug("[BlakePlugin.DocsRenderer] Resetting DocumentSectionRenderer state.");
+        _stack.Clear();
+        _sections.Clear();
+    }
+
     protected override void Write(HtmlRenderer renderer, HeadingBlock block)
     {
         logger?.LogDebug("[BlakePlugin.DocsRenderer] Rendering heading: {Level} - {heading}", block.Level, block.Inline?.ToString() ?? "null");

--- a/src/MarkdownExtensions/FinalizeDocumentRenderer.cs
+++ b/src/MarkdownExtensions/FinalizeDocumentRenderer.cs
@@ -11,6 +11,9 @@ public class FinalizingDocumentRenderer(DocumentSectionRenderer sectionRenderer,
     {
         logger?.LogDebug("[BlakePlugin.DocsRenderer] Finalizing document rendering.");
 
+        // Reset the section renderer state for each new document
+        sectionRenderer.Reset();
+
         foreach (var block in document)
         {
             logger?.LogDebug("[BlakePlugin.DocsRenderer] Processing block: {Name}", block.GetType().Name);


### PR DESCRIPTION
Introduce a Reset method to clear the state of DocumentSectionRenderer, invoked during the finalization of document rendering to ensure a clean slate for each new document.

Fixes #1