### PR TITLE
Fix mobile TOC issues

### DIFF
--- a/src/BlakePlugin.DocsRenderer.csproj
+++ b/src/BlakePlugin.DocsRenderer.csproj
@@ -41,6 +41,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Blazicons.Bootstrap" Version="2.3.40" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.7" />
 		<PackageReference Include="Blake.BuildTools" Version="1.0.10" />
 	</ItemGroup>

--- a/src/Components/SiteTocMobile.razor
+++ b/src/Components/SiteTocMobile.razor
@@ -1,5 +1,6 @@
 ﻿@using BlakePlugin.DocsRenderer.Types
 @using Microsoft.AspNetCore.Components.Routing
+@using Blazicons
 
 @if (Nodes?.Any() == true)
 {
@@ -8,19 +9,20 @@
         {
             var expanded = IsExpanded(node);
             var active = IsActive(node);
+            var svg = IsExpanded(node) ? BootstrapIcon.ChevronDown : BootstrapIcon.ChevronRight;
 
             <li class="nav-item bdr-toc-item">
                 @if (node.Children.Any())
                 {
-                    <div class="bdr-toc-row d-flex align-items-center @(active ? "active" : "")" 
+                    <div class="bdr-toc-row d-flex align-items-center @(active ? "active" : "")"
                          @onclick="() => ToggleExpanded(node.Slug)"
-                         role="button" 
-                         tabindex="0" 
+                         role="button"
+                         tabindex="0"
                          aria-expanded="@expanded">
-                        <NavLink class="bdr-toc-link flex-grow-1" href="@node.Slug">
+                        <Blazicon Svg="@svg" />
+                        <span class="bdr-toc-link flex-grow-1" href="@node.Slug">
                             @node.Text
-                        </NavLink>
-                        <span class="bdr-chevron bi @(expanded ? "bi-chevron-down" : "bi-chevron-right") ms-2"></span>
+                        </span>
                     </div>
                 }
                 else

--- a/src/Components/SiteTocMobile.razor
+++ b/src/Components/SiteTocMobile.razor
@@ -20,7 +20,7 @@
                          tabindex="0"
                          aria-expanded="@expanded">
                         <Blazicon Svg="@svg" />
-                        <span class="bdr-toc-link flex-grow-1" href="@node.Slug">
+                        <span class="bdr-toc-link flex-grow-1">
                             @node.Text
                         </span>
                     </div>

--- a/src/wwwroot/lib/css/plugin.css
+++ b/src/wwwroot/lib/css/plugin.css
@@ -378,8 +378,6 @@ div.code-toolbar {
 
 /* Page TOC Mobile Styles */
 .bdr-page-toc-mobile {
-    background-color: rgba(248, 249, 250, 0.8);
-    border-radius: 0.5rem;
     padding: 1rem;
     margin-bottom: 1.5rem;
     border: 1px solid rgba(0, 0, 0, 0.125);


### PR DESCRIPTION
This pull request updates the mobile table of contents (`SiteTocMobile.razor`) to use SVG icons from the `Blazicons.Bootstrap` package instead of Bootstrap icon fonts, resulting in improved rendering and maintainability. It also updates the project dependencies and slightly adjusts the mobile TOC styling.

**Icon rendering improvements:**

* Replaced Bootstrap icon font chevrons with SVG icons from the `Blazicons.Bootstrap` package in the mobile TOC, using the `Blazicon` component and switching icons based on expansion state. (`src/Components/SiteTocMobile.razor`) [[1]](diffhunk://#diff-a9a344ec26dbaac650eb4341cc3dbe49bafc1a0f02842e7c415a5d00d8377d6eR12) [[2]](diffhunk://#diff-a9a344ec26dbaac650eb4341cc3dbe49bafc1a0f02842e7c415a5d00d8377d6eL20-R25)
* Added the `Blazicons.Bootstrap` NuGet package to the project dependencies. (`src/BlakePlugin.DocsRenderer.csproj`)
* Updated imports to include `Blazicons` in the mobile TOC component. (`src/Components/SiteTocMobile.razor`)

**Styling adjustments:**

* Removed background color and border radius from the `.bdr-page-toc-mobile` class to simplify the mobile TOC appearance. (`src/wwwroot/lib/css/plugin.css`)